### PR TITLE
Fix keras and tensorflow versions

### DIFF
--- a/webinar-0620/requirements.txt
+++ b/webinar-0620/requirements.txt
@@ -1,2 +1,2 @@
-keras
-tensorflow>=2.2
+keras==2.4.0
+tensorflow==2.3.0


### PR DESCRIPTION
Under the requirements, currently tensorflow 2.6 and keras 2.6 are used. This leads to the following error when executing the command from the [basic tutorial for executing a code from a remote repository](https://clear.ml/docs/latest/docs/guides/clearml-task/clearml_task_tutorial):
```
Traceback (most recent call last):
  File "webinar-0620/keras_mnist.py", line 48, in <module>
    y_train = keras.utils.to_categorical(y_train, args.num_classes)
AttributeError: module 'keras.utils' has no attribute 'to_categorical'
```

Fixing the versions to keras==2.4.0 and tensorflow==2.3.0 removes the issue, see [here](https://datascience.stackexchange.com/a/96885).